### PR TITLE
Disable this option by default

### DIFF
--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -1307,7 +1307,7 @@ public class PatcherConfig extends Config {
         description = "Remove transparent pixels on heads instead of turning them black.",
         category = "Experimental", subcategory = "Head Rendering"
     )
-    public static boolean improvedHeadRendering = true;
+    public static boolean improvedHeadRendering = false;
 
     @Info(
         text = "This may cause stuff with animations to feel \"choppy\".",


### PR DESCRIPTION
## Description
Turn off “Improved Head Rendering” by default, as it makes most heads look odd.

## Related Issue(s)

## How to test
Delete PolyPatcher config, and replace the old version with this one.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or “NONE” if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->