### PR TITLE
optimize beacon beam rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ This work, "PolyPatcher", is adapted from ["Patcher"](https://sk1er.club/mods/pa
 - Boost performance by batch-drawing tile entities
 - Boost performance by reducing quad counts in item models
 - Boost performance by decreasing size of sine and cosine lookup tables
+- Boost performance by only rendering beacon beams once instead of twice per frame
 - Improve speed when changing language, mipmap level, and anisotropic filtering level
 - Fix Forge held item lighting to match vanilla
 - Fix vanilla bug where entering an entity in spectator mode while in third person applies shaders

--- a/src/main/java/club/sk1er/patcher/mixins/performance/RenderChunkMixin_OptimizeBeaconBeamRendering.java
+++ b/src/main/java/club/sk1er/patcher/mixins/performance/RenderChunkMixin_OptimizeBeaconBeamRendering.java
@@ -11,7 +11,9 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(RenderChunk.class)
+//#endif
 public class RenderChunkMixin_OptimizeBeaconBeamRendering {
+//#if MC==10809
     /**
      * Minecraft typically renders the beacon beam twice per frame. This is noticeable by comparing the opacity of the
      * beacon beam when the beacon is in view versus when it's out of view (fly 50 blocks above, for instance).
@@ -24,5 +26,6 @@ public class RenderChunkMixin_OptimizeBeaconBeamRendering {
         TileEntitySpecialRenderer<TileEntity> tileentityspecialrenderer = TileEntityRendererDispatcher.instance.getSpecialRenderer(tileEntityIn);
         if (!tileentityspecialrenderer.forceTileEntityRender()) instance.addTileEntity(tileEntityIn);
     }
-}
 //#endif
+}
+

--- a/src/main/java/club/sk1er/patcher/mixins/performance/RenderChunkMixin_OptimizeBeaconBeamRendering.java
+++ b/src/main/java/club/sk1er/patcher/mixins/performance/RenderChunkMixin_OptimizeBeaconBeamRendering.java
@@ -1,0 +1,28 @@
+package club.sk1er.patcher.mixins.performance;
+
+//#if MC==10809
+import net.minecraft.client.renderer.chunk.CompiledChunk;
+import net.minecraft.client.renderer.chunk.RenderChunk;
+import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.tileentity.TileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(RenderChunk.class)
+public class RenderChunkMixin_OptimizeBeaconBeamRendering {
+    /**
+     * Minecraft typically renders the beacon beam twice per frame. This is noticeable by comparing the opacity of the
+     * beacon beam when the beacon is in view versus when it's out of view (fly 50 blocks above, for instance).
+     * <p>
+     * This fix is based off a Forge PR that was added to 1.11.x:
+     * <a href="https://github.com/MinecraftForge/MinecraftForge/pull/3651/files">forge PR</a>
+     */
+    @Redirect(method = "rebuildChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/chunk/CompiledChunk;addTileEntity(Lnet/minecraft/tileentity/TileEntity;)V"))
+    private void patcher$renderBeamOnce(CompiledChunk instance, TileEntity tileEntityIn) {
+        TileEntitySpecialRenderer<TileEntity> tileentityspecialrenderer = TileEntityRendererDispatcher.instance.getSpecialRenderer(tileEntityIn);
+        if (!tileentityspecialrenderer.forceTileEntityRender()) instance.addTileEntity(tileEntityIn);
+    }
+}
+//#endif

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -238,6 +238,7 @@
     "performance.NBTTagStringMixin_DataCache",
     "performance.NetHandlerPlayClientMixin_InstantDimensionSwapping",
     "performance.NodeProcessorMixin_MemoryLeak",
+    "performance.RenderChunkMixin_OptimizeBeaconBeamRendering",
     "performance.RenderEntityItemMixin_EntityCulling",
     "performance.RenderGlobalMixin_LimitVisGraphScan",
     "performance.ResourcePackRepositoryMixin_FasterSearching",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Minecraft typically renders the beacon beam twice per frame. This is noticeable by comparing the opacity of the
beacon beam when the beacon is in view versus when it's out of view (fly 50 blocks above, for instance).

This fix is based off a Forge PR that was added to 1.11.x:
https://github.com/MinecraftForge/MinecraftForge/pull/3651/files

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #38

## How to test
<!-- Provide steps to test this PR -->
Place a beacon beam, check opacity, go up and check opacity. You can look up and down to get the beacon block in and out of view to test once you are high up

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Optimize beacon beam rendering by only rendering the beacon beam once instead of twice per frame.
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->