### PR TITLE
dont try to render removed tile entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ This work, "PolyPatcher", is adapted from ["Patcher"](https://sk1er.club/mods/pa
 - Fix vanilla bug where enchantment glint takes up the whole slot
 - Fix vanilla bug where items glitch out when using negative scale
 - Fix vanilla bug where pumpkin overlay shows in spectator mode
+- Fix vanilla bug where invalid tile entities try to render
 - Fix vanilla sky lighting calculation
 - Fix texture manager memory leak
 - Fix compatability with LoliASM/CensoredASM

--- a/src/main/java/club/sk1er/patcher/mixins/performance/TileEntityRendererDispatcherMixin_BatchDraw.java
+++ b/src/main/java/club/sk1er/patcher/mixins/performance/TileEntityRendererDispatcherMixin_BatchDraw.java
@@ -12,7 +12,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = TileEntityRendererDispatcher.class)
 public class TileEntityRendererDispatcherMixin_BatchDraw {
-
     //#if MC==10809
     @Unique private boolean patcher$drawingBatch = false;
 
@@ -36,5 +35,4 @@ public class TileEntityRendererDispatcherMixin_BatchDraw {
         return (!PatcherConfig.batchModelRendering || patcher$drawingBatch) && instance.hasFastRenderer();
     }
     //#endif
-
 }

--- a/src/main/java/club/sk1er/patcher/mixins/performance/TileEntityRendererDispatcherMixin_RemoveInvalidEntities.java
+++ b/src/main/java/club/sk1er/patcher/mixins/performance/TileEntityRendererDispatcherMixin_RemoveInvalidEntities.java
@@ -1,6 +1,5 @@
 package club.sk1er.patcher.mixins.performance;
 
-//#if MC==10809
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
@@ -10,7 +9,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(TileEntityRendererDispatcher.class)
-//#endif
 public class TileEntityRendererDispatcherMixin_RemoveInvalidEntities {
     //#if MC==10809
     @Inject(method = "getSpecialRenderer", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/club/sk1er/patcher/mixins/performance/TileEntityRendererDispatcherMixin_RemoveInvalidEntities.java
+++ b/src/main/java/club/sk1er/patcher/mixins/performance/TileEntityRendererDispatcherMixin_RemoveInvalidEntities.java
@@ -1,5 +1,6 @@
 package club.sk1er.patcher.mixins.performance;
 
+//#if MC==10809
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
@@ -9,11 +10,14 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(TileEntityRendererDispatcher.class)
+//#endif
 public class TileEntityRendererDispatcherMixin_RemoveInvalidEntities {
+    //#if MC==10809
     @Inject(method = "getSpecialRenderer", at = @At("HEAD"), cancellable = true)
     private <T extends TileEntity> void patcher$returnNullIfInvalid(TileEntity tileEntityIn, CallbackInfoReturnable<TileEntitySpecialRenderer<T>> cir) {
         if (tileEntityIn == null || tileEntityIn.isInvalid()) {
             cir.setReturnValue(null);
         }
     }
+    //#endif
 }

--- a/src/main/java/club/sk1er/patcher/mixins/performance/TileEntityRendererDispatcherMixin_RemoveInvalidEntities.java
+++ b/src/main/java/club/sk1er/patcher/mixins/performance/TileEntityRendererDispatcherMixin_RemoveInvalidEntities.java
@@ -1,0 +1,19 @@
+package club.sk1er.patcher.mixins.performance;
+
+import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.tileentity.TileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(TileEntityRendererDispatcher.class)
+public class TileEntityRendererDispatcherMixin_RemoveInvalidEntities {
+    @Inject(method = "getSpecialRenderer", at = @At("HEAD"), cancellable = true)
+    private <T extends TileEntity> void patcher$returnNullIfInvalid(TileEntity tileEntityIn, CallbackInfoReturnable<TileEntitySpecialRenderer<T>> cir) {
+        if (tileEntityIn == null || tileEntityIn.isInvalid()) {
+            cir.setReturnValue(null);
+        }
+    }
+}

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -248,6 +248,7 @@
     "performance.TextureManagerMixin_MemoryLeak",
     "performance.TileEntityMobSpawnerRendererMixin_EntityCulling",
     "performance.TileEntityRendererDispatcherMixin_BatchDraw",
+    "performance.TileEntityRendererDispatcherMixin_RemoveInvalidEntities",
     "performance.VisGraphMixin_LimitScan",
     "performance.WorldClientMixin_AnimationTick",
     "performance.WorldMixin_Optimization",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
forge: https://github.com/MinecraftForge/MinecraftForge/pull/4811
mojira issue: https://bugs.mojang.com/browse/MC-123363
crash is not relevant pre-1.13 but still an issue i believe. i do not know a way to test it

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fix vanilla bug where invalid tile entities try to render
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->