### PR TITLE
early light init fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ This work, "PolyPatcher", is adapted from ["Patcher"](https://sk1er.club/mods/pa
 - Fix vanilla bug where entities don't render at certain camera angles below Y=0 and above Y=255
 - Fix vanilla bug where invalid tile entities try to render
 - Fix vanilla sky lighting calculation
-- Fix texture manager memory leak
+- Fix vanilla light initializing too early
+- Fix vanilla texture manager memory leak
 - Fix compatability with LoliASM/CensoredASM
 - Backport entity glow effect
 - Add ability to change HUD Caching FPS

--- a/src/main/java/club/sk1er/patcher/mixins/performance/WorldMixin_FixEarlyLightInitialization.java
+++ b/src/main/java/club/sk1er/patcher/mixins/performance/WorldMixin_FixEarlyLightInitialization.java
@@ -1,0 +1,38 @@
+package club.sk1er.patcher.mixins.performance;
+
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.EnumSkyBlock;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(World.class)
+public abstract class WorldMixin_FixEarlyLightInitialization {
+    //#if MC==10809
+    @Shadow
+    public abstract boolean isAreaLoaded(BlockPos par1, int par2, boolean par3);
+    @Unique
+    private int patcher$range = 17;
+
+    @ModifyConstant(method = "checkLightFor", constant = @Constant(intValue = 17, ordinal = 0))
+    private int patcher$modifyRange(int constant) {
+        return 16;
+    }
+
+    @ModifyConstant(method = "checkLightFor", constant = {@Constant(intValue = 17, ordinal = 0), @Constant(intValue = 17, ordinal = 2)})
+    private int patcher$modifyRange2(int constant) {
+        return this.patcher$range;
+    }
+
+    @Inject(method = "checkLightFor", at = @At(value = "INVOKE", target = "Lnet/minecraft/profiler/Profiler;startSection(Ljava/lang/String;)V", ordinal = 0, shift = At.Shift.BEFORE))
+    private void patcher$modifyRange3(EnumSkyBlock lightType, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        this.patcher$range = this.isAreaLoaded(pos, 18, false) ? 17 : 15;
+    }
+    //#endif
+}

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -258,6 +258,7 @@
     "performance.TileEntityRendererDispatcherMixin_RemoveInvalidEntities",
     "performance.VisGraphMixin_LimitScan",
     "performance.WorldClientMixin_AnimationTick",
+    "performance.WorldMixin_FixEarlyLightInitialization",
     "performance.WorldMixin_Optimization",
     "performance.WorldMixin_TileEntityUnload",
     "performance.forge.ASMDataTableMixin_ComputeParallel",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fix vanilla light initializing too early
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->