### PR TITLE
fix MC-53850

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ This work, "PolyPatcher", is adapted from ["Patcher"](https://sk1er.club/mods/pa
 - Fix vanilla bug where a spaces are not trimmed in server address fields
 - Fix vanilla bug where entities don't render at certain camera angles below Y=0 and above Y=255
 - Fix vanilla bug where invalid tile entities try to render
+- Fix vanilla bug where damaged invulnerable entities stop rendering
 - Fix vanilla sky lighting calculation
 - Fix vanilla light initializing too early
 - Fix vanilla texture manager memory leak

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityExpOrbMixin_RenderDamagedInvulnerables.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityExpOrbMixin_RenderDamagedInvulnerables.java
@@ -1,0 +1,28 @@
+package club.sk1er.patcher.mixins.bugfixes;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityXPOrb;
+import net.minecraft.util.DamageSource;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(EntityXPOrb.class)
+public abstract class EntityExpOrbMixin_RenderDamagedInvulnerables
+    //#if MC==10809
+    extends Entity
+    //#endif
+{
+    //#if MC==10809
+    public EntityExpOrbMixin_RenderDamagedInvulnerables(World worldIn) {
+        super(worldIn);
+    }
+
+    @Inject(method = "attackEntityFrom", at = @At("HEAD"), cancellable = true)
+    private void patcher$properInvulnerableCheck(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        if (this.worldObj.isRemote || this.isDead) cir.setReturnValue(false);
+    }
+    //#endif
+}

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityExpOrbMixin_RenderDamagedInvulnerables.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityExpOrbMixin_RenderDamagedInvulnerables.java
@@ -22,7 +22,7 @@ public abstract class EntityExpOrbMixin_RenderDamagedInvulnerables
 
     @Inject(method = "attackEntityFrom", at = @At("HEAD"), cancellable = true)
     private void patcher$properInvulnerableCheck(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
-        if (this.worldObj.isRemote || this.isDead) cir.setReturnValue(false);
+        if (this.worldObj.isRemote) cir.setReturnValue(false);
     }
     //#endif
 }

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityItemMixin_RenderDamagedInvulnerables.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityItemMixin_RenderDamagedInvulnerables.java
@@ -22,7 +22,7 @@ public abstract class EntityItemMixin_RenderDamagedInvulnerables
 
     @Inject(method = "attackEntityFrom", at = @At("HEAD"), cancellable = true)
     private void patcher$properInvulnerableCheck(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
-        if (this.worldObj.isRemote || this.isDead) cir.setReturnValue(false);
+        if (this.worldObj.isRemote) cir.setReturnValue(false);
     }
     //#endif
 }

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityItemMixin_RenderDamagedInvulnerables.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityItemMixin_RenderDamagedInvulnerables.java
@@ -1,0 +1,28 @@
+package club.sk1er.patcher.mixins.bugfixes;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.util.DamageSource;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(EntityItem.class)
+public abstract class EntityItemMixin_RenderDamagedInvulnerables
+    //#if MC==10809
+    extends Entity
+    //#endif
+{
+    //#if MC==10809
+    public EntityItemMixin_RenderDamagedInvulnerables(World worldIn) {
+        super(worldIn);
+    }
+
+    @Inject(method = "attackEntityFrom", at = @At("HEAD"), cancellable = true)
+    private void patcher$properInvulnerableCheck(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        if (this.worldObj.isRemote || this.isDead) cir.setReturnValue(false);
+    }
+    //#endif
+}

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -40,6 +40,8 @@
     "bugfixes.BlockModelRendererMixin_SmoothLighting",
     "bugfixes.CommandHandlerMixin_CaseCommands",
     "bugfixes.ContainerMixin_PlaySound",
+    "bugfixes.EntityExpOrbMixin_RenderDamagedInvulnerables",
+    "bugfixes.EntityItemMixin_RenderDamagedInvulnerables",
     "bugfixes.EntityLivingBaseMixin_MouseDelayFix",
     "bugfixes.EntityMixin_FixedBrightness",
     "bugfixes.EntityMixin_FixGlow",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

!! this changes vanilla behavior

mojira: https://bugs.mojang.com/browse/MC-53850
forge: https://github.com/MinecraftForge/MinecraftForge/pull/3807

this is fixed in forge 1.11+ so i dont think itd be a problem in 1.8 even though its not a fully client sided fix. it was a very simple backport though so thought id pr it regardless

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

item command for 1.8.9: /summon Item ~2 ~ ~ {Item:{id:stone,Count:1},Invulnerable:1}
xp command for 1.8.9: /summon Item ~2 ~ ~ {Item:{id:stone,Count:1},Invulnerable:1}

you can tell its not vanilla as without the fix, setting the xp orb on fire will make the armor stand stop in place until you are close enough to collect it, meanwhile with the fix the armor stand will continue to slowly follow you around even while on/after the fire. since its fixed in forge i dont think its an issue here

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fix vanilla bug where damaged invulnerable entities stop rendering
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->