### PR TITLE
optimize entity glow logic

### DIFF
--- a/src/main/java/club/sk1er/patcher/mixins/accessors/EntityAccessor.java
+++ b/src/main/java/club/sk1er/patcher/mixins/accessors/EntityAccessor.java
@@ -1,0 +1,13 @@
+package club.sk1er.patcher.mixins.accessors;
+
+import net.minecraft.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Entity.class)
+public interface EntityAccessor {
+    //#if MC==11202
+    //$$ @Accessor
+    //$$ boolean isGlowing();
+    //#endif
+}

--- a/src/main/java/club/sk1er/patcher/mixins/accessors/RenderManagerAccessor.java
+++ b/src/main/java/club/sk1er/patcher/mixins/accessors/RenderManagerAccessor.java
@@ -14,7 +14,4 @@ public interface RenderManagerAccessor {
 
     @Accessor
     double getRenderPosZ();
-
-    @Accessor
-    boolean isRenderOutlines();
 }

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/RenderGlobalMixin_FixGlow.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/RenderGlobalMixin_FixGlow.java
@@ -26,12 +26,14 @@ public class RenderGlobalMixin_FixGlow implements EntityExt {
 
     @Redirect(method = "isRenderEntityOutlines", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/entity/EntityPlayerSP;isSpectator()Z"))
     private boolean patcher$removeSpectatorCheck(EntityPlayerSP instance) {
-        return true;
+        if (PatcherConfig.entityOutlines) return true;
+        return instance.isSpectator();
     }
 
     @Redirect(method = "isRenderEntityOutlines", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/settings/KeyBinding;isKeyDown()Z"))
-    private boolean patcher$redirectKeyCheck(KeyBinding instance) {
-        return true;
+    private boolean patcher$removeKeyCheck(KeyBinding instance) {
+        if (PatcherConfig.entityOutlines) return true;
+        return instance.isKeyDown();
     }
 
     @Redirect(method = "renderEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;shouldRenderInPass(I)Z", ordinal = 1))

--- a/src/main/java/club/sk1er/patcher/util/world/render/culling/EntityCulling.java
+++ b/src/main/java/club/sk1er/patcher/util/world/render/culling/EntityCulling.java
@@ -2,6 +2,7 @@ package club.sk1er.patcher.util.world.render.culling;
 
 import club.sk1er.patcher.Patcher;
 import club.sk1er.patcher.config.PatcherConfig;
+import club.sk1er.patcher.ducks.EntityExt;
 import club.sk1er.patcher.mixins.accessors.RenderManagerAccessor;
 import club.sk1er.patcher.util.chat.ChatUtilities;
 import cc.polyfrost.oneconfig.libs.universal.UDesktop;
@@ -45,9 +46,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * Used for stopping entities from rendering if they are not visible to the player
  * <p>
- * Subsequent entity on entity occlusion derived from https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection
+ * Subsequent entity on entity occlusion derived from <a href="https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection">wikipedia</a>
  */
-public class EntityCulling {
+public class EntityCulling implements EntityExt {
 
     private static final Minecraft mc = Minecraft.getMinecraft();
     private static final RenderManager renderManager = mc.getRenderManager();
@@ -172,7 +173,7 @@ public class EntityCulling {
      * @return true if the entity rendering should be skipped
      */
     private static boolean checkEntity(Entity entity) {
-        if (renderingSpawnerEntity || renderManagerAccessor.isRenderOutlines()) return false;
+        if (renderingSpawnerEntity || ((EntityExt) entity).patcher$isGlowing()) return false;
         OcclusionQuery query = queries.computeIfAbsent(entity.getUniqueID(), OcclusionQuery::new);
         if (query.refresh) {
             query.nextQuery = getQuery();

--- a/src/main/java/club/sk1er/patcher/util/world/render/culling/EntityCulling.java
+++ b/src/main/java/club/sk1er/patcher/util/world/render/culling/EntityCulling.java
@@ -173,7 +173,14 @@ public class EntityCulling implements EntityExt {
      * @return true if the entity rendering should be skipped
      */
     private static boolean checkEntity(Entity entity) {
-        if (renderingSpawnerEntity || ((EntityExt) entity).patcher$isGlowing()) return false;
+        if (renderingSpawnerEntity ||
+            //#if MC==10809
+            ((EntityExt) entity).patcher$isGlowing()
+            //#else
+            //$$ ((EntityAccessor) entity).isGlowing()
+            //#endif
+        )
+            return false;
         OcclusionQuery query = queries.computeIfAbsent(entity.getUniqueID(), OcclusionQuery::new);
         if (query.refresh) {
             query.nextQuery = getQuery();

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -9,6 +9,7 @@
   },
   "client": [
     "accessors.BlockAccessor",
+    "accessors.EntityAccessor",
     "accessors.EntityArrowAccessor",
     "accessors.EventBusAccessor",
     "accessors.FontRendererAccessor",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
instead of basically forcing isEntityOutlines to be true, lets only do it when the option is enabled

also im not sure checking isEntityOutlines is a good idea for entity culling. unless im misunderstanding the code this will apply to all entities while the option is enabled, so changed that to directly check if that entity itself is glowing. **THIS LAST PART NEEDS TO BE TESTED**

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->