### PR TITLE
Add DE QWERTZ

### DIFF
--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -116,7 +116,7 @@ public class PatcherConfig extends Config {
         name = "Keyboard Layout",
         description = "The layout of your keyboard, used to fix input bugs accordingly.",
         category = "Bug Fixes", subcategory = "Linux",
-        options = {"QWERTY", "BE AZERTY", "FR AZERTY"}
+        options = {"QWERTY", "BE AZERTY", "FR AZERTY", "DE QWERTZ"}
     )
     public static int keyboardLayout = 0;
 

--- a/src/main/java/club/sk1er/patcher/util/keybind/linux/LinuxKeybindFix.java
+++ b/src/main/java/club/sk1er/patcher/util/keybind/linux/LinuxKeybindFix.java
@@ -43,6 +43,17 @@ public class LinuxKeybindFix {
             put('_', 7);
             put('ç', 8);
         }});
+        put(3, new HashMap<Character, Integer>() {{ // DE QWERTZ
+            put('!', 0);
+            put('"', 1);
+            put('§', 2);
+            put('$', 3);
+            put('%', 4);
+            put('&', 5);
+            put('/', 6);
+            put('(', 7);
+            put(')', 8);
+        }});
     }};
 
     @SubscribeEvent


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds DE QWERTZ layout to the Linux keybind fix.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #N/A

## How to test
<!-- Provide steps to test this PR -->
Be on Linux, use German QWERTZ layout, press 1-9 while holding shift.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Add DE QWERTZ to Linux Keybind Fix
```

<!--
## Documentation
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->