### PR TITLE
add all blocks for better camera

### DIFF
--- a/src/main/java/club/sk1er/patcher/mixins/features/WorldMixin_CameraPerspective.java
+++ b/src/main/java/club/sk1er/patcher/mixins/features/WorldMixin_CameraPerspective.java
@@ -1,0 +1,34 @@
+package club.sk1er.patcher.mixins.features;
+
+import club.sk1er.patcher.config.PatcherConfig;
+import com.google.common.collect.Sets;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Set;
+
+@Mixin(World.class)
+public abstract class WorldMixin_CameraPerspective {
+    @Unique
+    private static final Set<Block> patcher$ignoredBlocks = Sets.newHashSet(
+        Blocks.glass,
+        Blocks.stained_glass,
+        Blocks.glass_pane,
+        Blocks.stained_glass_pane,
+        Blocks.iron_bars
+    );
+
+    @Redirect(method = "rayTraceBlocks(Lnet/minecraft/util/Vec3;Lnet/minecraft/util/Vec3;ZZZ)Lnet/minecraft/util/MovingObjectPosition;", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;getCollisionBoundingBox(Lnet/minecraft/world/World;Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;)Lnet/minecraft/util/AxisAlignedBB;", ordinal = 1))
+    private AxisAlignedBB patcher$shouldCancel(Block instance, World world, BlockPos blockPos, IBlockState iBlockState) {
+        if (PatcherConfig.betterCamera && patcher$ignoredBlocks.contains(iBlockState.getBlock())) return null;
+        return instance.getCollisionBoundingBox(world, blockPos, iBlockState);
+    }
+}

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -190,6 +190,7 @@
     "features.TileEntityEndPortalRendererMixins_CancelRender",
     "features.TileEntityMixin_RenderDistance",
     "features.TileEntitySkullRendererMixin_CancelRender",
+    "features.WorldMixin_CameraPerspective",
     "features.containeropacity.GuiChestMixin_ContainerOpacity",
     "features.containeropacity.GuiInventoryMixin_ContainerOpacity",
     "features.cropheight.BlockCactusMixin_CropHitbox",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
in latest minecraft all transparent (actually transparent, so no soul sand and stuff) blocks do not block camera movement

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
compare blocks in f5 in 1.8.9, with this feature, and 1.21+

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Allow Better Camera to work for all transparent blocks, similar to modern versions of Minecraft 
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->