### PR TITLE
fix bossbar

### DIFF
--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiIngameMixin_FixBossbarWidth.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiIngameMixin_FixBossbarWidth.java
@@ -1,0 +1,15 @@
+package club.sk1er.patcher.mixins.bugfixes;
+
+import net.minecraft.client.gui.GuiIngame;
+import net.minecraft.entity.boss.BossStatus;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(GuiIngame.class)
+public class GuiIngameMixin_FixBossbarWidth {
+    @Redirect(method = "renderBossHealth", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/boss/BossStatus;healthScale:F"))
+    private float patcher$clampBossBarWidth() {
+        return Math.min(BossStatus.healthScale, 1.0F);
+    }
+}

--- a/src/main/java/club/sk1er/patcher/mixins/features/EntityRendererMixin_CameraPerspective.java
+++ b/src/main/java/club/sk1er/patcher/mixins/features/EntityRendererMixin_CameraPerspective.java
@@ -11,7 +11,6 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(EntityRenderer.class)
 public class EntityRendererMixin_CameraPerspective {
-
     @Redirect(method = "orientCamera", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/WorldClient;rayTraceBlocks(Lnet/minecraft/util/Vec3;Lnet/minecraft/util/Vec3;)Lnet/minecraft/util/MovingObjectPosition;"))
     private MovingObjectPosition patcher$changeBlockingType(WorldClient instance, Vec3 from, Vec3 to) {
         return PatcherConfig.betterCamera

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -53,6 +53,7 @@
     "bugfixes.GuiGameOverMixin_ResolveButtonClick",
     "bugfixes.GuiIngameForgeMixin_FixProfilerSection",
     "bugfixes.GuiIngameForgeMixin_HotbarAlpha",
+    "bugfixes.GuiIngameMixin_FixBossbarWidth",
     "bugfixes.GuiIngameMixin_RemoveSpectatorPumpkinOverlay",
     "bugfixes.GuiIngameMixin_ScoreboardTextTransparency",
     "bugfixes.GuiLanguageMixin_ResetUnicodeFont",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
https://discord.com/channels/822066990423605249/1297626978165461175/1297626978165461175

Unable to replicate the issue, and not about to wait for a skyblock event or whatever. this is the only thing i can think of that would cause this. cant replicate it even with insane aspect ratios, and you cant set boss health above their hardcoded values in vanilla 1.8.9. not tested at all, dont know if this fixes anything.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # https://discord.com/channels/822066990423605249/1297626978165461175/1297626978165461175

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fix boss bars being longer than the intended width
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->