### PR TITLE
Update PatcherMenuEditor.java

### DIFF
--- a/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
+++ b/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
@@ -190,6 +190,7 @@ public class PatcherMenuEditor {
 
     @SubscribeEvent
     public void keyboardInput(GuiScreenEvent.KeyboardInputEvent.Post event) {
+        if (!Keyboard.isCreated()) return;
         //#if MC==10809
         GuiScreen gui = event.gui;
         //#else
@@ -197,7 +198,7 @@ public class PatcherMenuEditor {
         //#endif
         if (gui instanceof GuiMainMenu) {
             int key = Keyboard.getEventKey();
-            if (Keyboard.isCreated() && Keyboard.isKeyDown(key) && !Keyboard.isRepeatEvent()) {
+            if (Keyboard.isKeyDown(key) && !Keyboard.isRepeatEvent()) {
                 int i = next + 1;
                 next = (key >> 3) * ((7 & key) + (i << 1)) == sequence[next] ? i : 0;
                 if (next > 9) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Potentially fixes a crash where keyboard is not created. In the past when I last submitted a fix, the crashlog specifically had the isKeyDown in stacktrace so I placed the created check there. Now another crash complains about keyboard being created for some event thing. Not sure if that's the getEventKey or what, but I don't see any harm in moving this check above to potentially catch that too.

Note: empty release note idk what to put for this

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->