### PR TITLE
Fix regression causing all spaces to be removed from server names

### DIFF
--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenAddServerMixin_RemoveSpaces.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenAddServerMixin_RemoveSpaces.java
@@ -10,6 +10,6 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public class GuiScreenAddServerMixin_RemoveSpaces {
     @Redirect(method = "actionPerformed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiTextField;getText()Ljava/lang/String;"))
     private String patcher$removeSpaces(GuiTextField guiTextField) {
-        return guiTextField.getText().replaceAll(" ", "");
+        return guiTextField.getText().trim();
     }
 }

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenServerListMixin_RemoveSpaces.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenServerListMixin_RemoveSpaces.java
@@ -10,6 +10,6 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public class GuiScreenServerListMixin_RemoveSpaces {
     @Redirect(method = "actionPerformed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiTextField;getText()Ljava/lang/String;"))
     private String patcher$removeSpaces(GuiTextField guiTextField) {
-        return guiTextField.getText().replaceAll(" ", "");
+        return guiTextField.getText().trim();
     }
 }


### PR DESCRIPTION
## Description
For some reason, #48 solves an issue caused by leading and trailing spaces in hostnames by... removing all spaces not only from the hostname, but also from the server name? I've replaced this behavior with `String.trim()`.

It's arguable whether what the aforementioned PR tries to fix is a real issue to begin with, but I still think it's a good QoL change, so I've also kept the behavior of trimming spaces from the server name.

## Related Issue(s)
N/A

## How to test
Try using spaces in a server name

## Release Notes
```release-note
Fix spaces being removed from server names
```