### PR TITLE
Remove damage tilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This work, "PolyPatcher", is adapted from ["Patcher"](https://sk1er.club/mods/pa
 - ~~**Remove Inverted Colors from Crosshair** - Remove the inverted color effect on the crosshair.~~ (replaced by [PolyCrosshair](https://modrinth.com/mod/crosshair))
 - **Fullbright** - Remove lighting updates, increasing visibility. (Can positively impact performance. May conflict with minimaps) *default
 - **Smart Fullbright** - Automatically Disable the Fullbright Effect when using OptiFine Shaders. (Requires Fullbright) *default
+- **Remove Damage Tilt** - Remove the screen tilt when taking damage.
 - **Disable Night Vision** *(not in original)* - Completely disables the effects of night vision.
 - **Cleaner Night Vision** *(not in original)* - Makes the night vision effect fade out instead of a flashing effect.
 - ~~**Show Own Nametag** - See your nametag in third person.~~ (replaced by [PolyNametag](https://modrinth.com/mod/polynametag))

--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -181,6 +181,13 @@ public class PatcherConfig extends Config {
     public static boolean smartFullbright = true;
 
     @Switch(
+        name = "Remove Damage Tilt",
+        description = "Remove the screen tilt effect when taking damage.",
+        category = "Miscellaneous", subcategory = "Rendering"
+    )
+    public static boolean removeDamageTilt = true;
+
+    @Switch(
         name = "Disable Night Vision",
         description = "Completely disable the effects of night vision.",
         category = "Miscellaneous", subcategory = "Overlays"

--- a/src/main/java/club/sk1er/patcher/mixins/features/EntityRendererMixin_DamageTilt.java
+++ b/src/main/java/club/sk1er/patcher/mixins/features/EntityRendererMixin_DamageTilt.java
@@ -1,0 +1,19 @@
+package club.sk1er.patcher.mixins.features;
+
+import club.sk1er.patcher.config.PatcherConfig;
+import net.minecraft.client.renderer.EntityRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityRenderer.class)
+public class EntityRendererMixin_DamageTilt {
+
+    @Inject(method = "hurtCameraEffect", at = @At(value = "HEAD"), cancellable = true)
+    public void patcher$hurtCameraEffect(float partialTicks, CallbackInfo ci) {
+        if (PatcherConfig.removeDamageTilt) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -142,6 +142,7 @@
     "features.EntityPlayerMixin_NaturalCapes",
     "features.EntityPlayerSPMixin_NauseaEffect",
     "features.EntityRendererMixin_CameraPerspective",
+    "features.EntityRendererMixin_DamageTilt",
     "features.EntityRendererMixin_Distortion",
     "features.EntityRendererMixin_Fog",
     "features.EntityRendererMixin_NightVisionEffect",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add "Remove Damage Tilt" option in "Miscellaneous" -> Rendering

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #96

## How to test
<!-- Provide steps to test this PR -->

Build both 1.8.9 and 1.12.2, and then test if your screen shakes after taking a damage.
Both versions have been tested by the author.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
add "remove damage tilt" option
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

No changes.