### PR TITLE
Set the unfocused FPS limit min value to 1

### DIFF
--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -340,7 +340,7 @@ public class PatcherConfig extends Config {
         name = "Unfocused FPS Amount",
         description = "Change the maximum FPS when you're not tabbed into the window, saving resources.",
         category = "Miscellaneous", subcategory = "General",
-        min = 15, max = 240
+        min = 1, max = 240
     )
     public static int unfocusedFPSAmount = 60;
 

--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -340,7 +340,7 @@ public class PatcherConfig extends Config {
         name = "Unfocused FPS Amount",
         description = "Change the maximum FPS when you're not tabbed into the window, saving resources.",
         category = "Miscellaneous", subcategory = "General",
-        min = 1, max = 240
+        min = 5, max = 240
     )
     public static int unfocusedFPSAmount = 60;
 


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->
This PR sets the minimum unfocused FPS limit to 1, making it much better for low-end devices.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->
Change the unfocused FPS limit to 1, tab out, and verify that it's working — that's it!

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```Change the minimum unfocused FPS value to 1
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->