### PR TITLE
Enable Check Armorstand Rules by default

### DIFF
--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -881,7 +881,7 @@ public class PatcherConfig extends Config {
             "but will resolve special entities being occluded when they typically shouldn't be.",
         category = "Performance", subcategory = "Culling"
     )
-    public static boolean checkArmorstandRules;
+    public static boolean checkArmorstandRules = true;
 
     @Switch(
         name = "Disable Enchantment Glint",


### PR DESCRIPTION
## Description
Changed Check Armorstand Rules to default enabled.

Having this off is known to hide important things such as cadavers for Vampire Slayer on Hypixel SkyBlock if Entity Culling is enabled.
<!-- Describe your changes in detail -->

## How to test
<!-- Provide steps to test this PR -->
Launch the game with PolyPatcher and no pre-existing config file and make sure "Check Armorstand Rules" was automatically enabled.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Check Armorstand Rules is now enabled by default
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A