### PR TITLE
Use HTTPS for OptiFine capes

### DIFF
--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/optifine/CapeUtilsMixin_UseHTTPS.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/optifine/CapeUtilsMixin_UseHTTPS.java
@@ -1,0 +1,19 @@
+package club.sk1er.patcher.mixins.bugfixes.optifine;
+
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Pseudo
+@Mixin(targets = "net.optifine.player.CapeUtils", remap = false)
+public class CapeUtilsMixin_UseHTTPS {
+    @Dynamic("OptiFine")
+    @ModifyConstant(
+        method = "downloadCape", constant = @Constant(stringValue = "http://s.optifine.net/capes/")
+    )
+    private String useHTTPS(String url) {
+        return "https://optifine.net/capes/";
+    }
+}

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/optifine/HttpUtilsMixin_UseHTTPS.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/optifine/HttpUtilsMixin_UseHTTPS.java
@@ -1,0 +1,20 @@
+package club.sk1er.patcher.mixins.bugfixes.optifine;
+
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Pseudo
+@Mixin(targets = "net.optifine.http.HttpUtils", remap = false)
+public class HttpUtilsMixin_UseHTTPS {
+    @Dynamic("OptiFine")
+    @ModifyConstant(
+        method = "downloadCape", constant = @Constant(stringValue = "http://s.optifine.net")
+    )
+    private String useHTTPS(String url) {
+        return "https://optifine.net";
+    }
+}
+

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -119,6 +119,7 @@
     "bugfixes.network.ServerListMixin_ResolveNpe",
     "bugfixes.network.packet.EntityPacketsMixin_ResolveNpe",
     "bugfixes.optifine.CapeUtilsMixin_UseHTTPS",
+    "bugfixes.optifine.HttpUtilsMixin_UseHTTPS",
     "bugfixes.optifine.RegionRenderCacheMixin_FixConnectedTextures",
     "bugfixes.optifine.RenderGlobalMixin_FixSkyVBOs",
     "bugfixes.render.entity.RenderArrowMixin_AlphaFix",

--- a/src/main/resources/mixins.patcher.json
+++ b/src/main/resources/mixins.patcher.json
@@ -118,6 +118,7 @@
     "bugfixes.network.ServerAddressMixin_ResolveCrash",
     "bugfixes.network.ServerListMixin_ResolveNpe",
     "bugfixes.network.packet.EntityPacketsMixin_ResolveNpe",
+    "bugfixes.optifine.CapeUtilsMixin_UseHTTPS",
     "bugfixes.optifine.RegionRenderCacheMixin_FixConnectedTextures",
     "bugfixes.optifine.RenderGlobalMixin_FixSkyVBOs",
     "bugfixes.render.entity.RenderArrowMixin_AlphaFix",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Makes OptiFine use HTTPS connection for capes

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Was on Discord, Wyvest told me to PR it

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->